### PR TITLE
build: updated build using the standard linux c++ compiler 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXX = g++
+CXX = c++
 CXXFLAGS = -g -Wall -Werror -I include
 
 SRC_FILES = src/main.cpp \

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ### Prerequisites
 
-- A C++ compiler (e.g., `g++`, `clang++`).
+- A C++ compiler (e.g., `g++`, `clang++`, `c++`).
 - Works on Linux and MacOS. For Windows, consider using WSL.
 - A terminal that supports ANSI escape sequences.
 
@@ -46,7 +46,7 @@ yay -S ttype
 
 #### Build it from source
 
-Note: If you are using clang instead of gcc, you have to change the Makefile by replacing `CXX=g++` with `CXX = clang++`
+Note: If you are using clang instead of gcc, you have to change the Makefile by replacing `CXX=c++` `CXX=g++` or `CXX = clang++`
 
 1. Clone the repository to your local machine:
 ```bash


### PR DESCRIPTION
instead of using g++ or clang++ using c++ compiler which is the base compiler which comes pre installed on most linux distros after build-devel on archlinux 